### PR TITLE
Missing dependency

### DIFF
--- a/example/example-client/README.md
+++ b/example/example-client/README.md
@@ -43,6 +43,8 @@ What is happening is:
                                                                                   (Storage$SignUrlOption/httpMethod HttpMethod/PUT)]))))
 ```
 
+For Python you can use [google.cloud.storage.blob.Blob.create_resumable_upload_session](https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.create_resumable_upload_session).
+
 ## Running
 
 Open `index.html`. Pick a file to upload. As soon as you pick the file, the upload will begin.

--- a/example/example-client/package.json
+++ b/example/example-client/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.7.4",
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-regenerator": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.7.4",
     "babel-preset-env": "^1.4.0",
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
The example was missing a depenency on `babel-plugin-transform-runtime` which is referenced in `.babelrc`.