### PR TITLE
Fix memory leak by not awaiting processIndex recursively

### DIFF
--- a/src/FileProcessor.js
+++ b/src/FileProcessor.js
@@ -23,7 +23,7 @@ class FileProcessor {
     const processIndex = async (index) => {
       if (index === totalChunks || index === endIndex) {
         debug('File process complete')
-        return
+        return true
       }
       if (this.paused) {
         await waitForUnpause()
@@ -36,8 +36,9 @@ class FileProcessor {
 
       const shouldContinue = await fn(checksum, index, chunk)
       if (shouldContinue !== false) {
-        await processIndex(index + 1)
+        return processIndex(index + 1)
       }
+      return false
     }
 
     const waitForUnpause = () => {


### PR DESCRIPTION
By returning the next call, we return a promise instead of awaiting it
ourselves. If we await it, we will retain memory from our own request
until all other requests has completed.

Fixes QubitProducts/gcs-browser-upload#4

Co-authored-by: Fredrik Østrem <fredrik.ostrem@cognite.com>
Co-authored-by: Michael Susæg <michael.susag@cognite.com>