### PR TITLE
Remove return value from start()

### DIFF
--- a/src/Upload.js
+++ b/src/Upload.js
@@ -49,7 +49,6 @@ export default class Upload {
     this.opts = opts
     this.meta = new FileMeta(opts.id, opts.file.size, opts.chunkSize, opts.storage)
     this.processor = new FileProcessor(opts.file, opts.chunkSize)
-    this.lastResult = null;
   }
 
   async start () {
@@ -96,7 +95,6 @@ export default class Upload {
       debug(` - End: ${end}`)
 
       const res = await safePut(opts.url, chunk, { headers })
-      this.lastResult = res;
       checkResponseStatus(res, opts, [200, 201, 308])
       debug(`Chunk upload succeeded, adding checksum ${checksum}`)
       meta.addChecksum(index, checksum)
@@ -147,7 +145,6 @@ export default class Upload {
     debug('Upload complete, resetting meta')
     meta.reset()
     this.finished = true
-    return this.lastResult
   }
 
   pause () {


### PR DESCRIPTION
The value currently returned by `start()` leaks implementation details without providing value to the API consumer, so it is better to remove it.

If anyone should need this feature, we invite them to fork this repo so they can customize the code to their needs.